### PR TITLE
Fix identity mapper includes.

### DIFF
--- a/core/modules/core/include/klepsydra/core/from_middleware_channel.h
+++ b/core/modules/core/include/klepsydra/core/from_middleware_channel.h
@@ -22,7 +22,6 @@
 
 #include <klepsydra/core/event_transform_forwarder.h>
 #include <klepsydra/serialization/mapper.h>
-#include <klepsydra/serialization/identity_mapper.h>
 
 namespace kpsr {
 template<class KpsrClass, class MddlwClass>


### PR DESCRIPTION
Identity mapper should be included in application, not in core.