### PR TITLE
Add setContainer api to high performance middleware providers.

### DIFF
--- a/high_performance/modules/high_performance/include/klepsydra/high_performance/data_multiplexer_middleware_provider.h
+++ b/high_performance/modules/high_performance/include/klepsydra/high_performance/data_multiplexer_middleware_provider.h
@@ -162,6 +162,13 @@ public:
                                                                                  transformFunction,
                                                                                  getPublisher()));
     }
+
+    void setContainer(Container * container) {
+        if (container) {
+            container->attach(&_publisher._publicationStats);
+            _subscriber.setContainer(container);
+        }
+    }
 private:
     EventData<TEvent> * _modelEvent;
 

--- a/high_performance/modules/high_performance/include/klepsydra/high_performance/event_loop_function_exec_listener.h
+++ b/high_performance/modules/high_performance/include/klepsydra/high_performance/event_loop_function_exec_listener.h
@@ -74,6 +74,12 @@ public:
         _externalEventEmitter.remove_listener(_listenerId);
     }
 
+    void setContainer(Container * container) {
+        _container = container;
+        if (this->_container != nullptr) {
+            this->_container->attach(_externalEventEmitter._listenerStats[_listenerId].get());
+        }
+    }
 private:
     Container * _container;
     std::string _eventName;

--- a/high_performance/modules/high_performance/include/klepsydra/high_performance/event_loop_middleware_provider.h
+++ b/high_performance/modules/high_performance/include/klepsydra/high_performance/event_loop_middleware_provider.h
@@ -164,6 +164,24 @@ public:
         return _eventLoop.isStarted();
     }
 
+    void setContainer(Container * container) {
+        if (!isRunning()) {
+            _container = container;
+            if (_scheduler && (_subscriberMap.size() == 1) && (_publisherMap.size() == 1)) {
+                if (_container) {
+                    for (auto& keyValue : _subscriberMap) {
+                        std::shared_ptr<EventLoopFunctionExecutorListener> schedulerSubscriber = std::static_pointer_cast<EventLoopFunctionExecutorListener>(keyValue.second);
+                        schedulerSubscriber->setContainer(container);
+                        Publisher<std::function<void()>> *schedulerPublisher = getPublisher<std::function<void()> > (keyValue.first, 0, nullptr, nullptr);
+                        _container->attach(&schedulerPublisher->_publicationStats);
+                    }
+                }
+            } else if ((_subscriberMap.size() > 0) || (_publisherMap.size() > 0 )) {
+                spdlog::info("Container cannot be attached to already existing subscribers or publishers. Only subscribers/publishers declared after this call will attach to container.");
+            }
+        }
+    }
+
 private:
 
     Container * _container;

--- a/high_performance/tests/high_performance_tests/CMakeLists.txt
+++ b/high_performance/tests/high_performance_tests/CMakeLists.txt
@@ -41,6 +41,6 @@ LINK_DIRECTORIES()
 #---------------------------------------------------#
 ADD_EXECUTABLE(${PROJ_NAME} ${${PROJ_NAME}_HEADERS} ${${PROJ_NAME}_SRC} )
 
-TARGET_LINK_LIBRARIES(${PROJ_NAME} kpsr_core atomic gtest_main)
+TARGET_LINK_LIBRARIES(${PROJ_NAME} kpsr_core kpsr_mem_core kpsr_high_performance atomic gtest_main)
 
 add_test(NAME ${PROJ_NAME} COMMAND ${PROJ_NAME} --output-on-failure --gtest_output=xml:gtestresults.xml)


### PR DESCRIPTION
This allows us to create a event loop provider before any containers
exist, and then later attach the containers. The advantage is that it
allows us to reuse existing event loops in kpsr::admin.

Reset spdlog default logger after unit tests.
