### PR TITLE
Fix memory leak in DDS, fix unit tests

### DIFF
--- a/core/modules/dds_mdlw/include/klepsydra/dds_core/dds_env.h
+++ b/core/modules/dds_mdlw/include/klepsydra/dds_core/dds_env.h
@@ -117,6 +117,9 @@ public:
            dds::sub::DataReader<kpsr_dds_core::DDSEnvironmentData> * dataReader,
            const std::string& rootNode = kpsr::DEFAULT_ROOT);
 
+
+    ~DDSEnv();
+
     /**
      * @brief getPropertyString
      * @param key
@@ -198,7 +201,7 @@ private:
     DDSConfigurationListener * _listener;
     std::string _ddsKey;
     long _timestamp;
-
+    bool _isEnvLocal;
 };
 }
 }

--- a/core/modules/dds_mdlw/src/dds_env.cpp
+++ b/core/modules/dds_mdlw/src/dds_env.cpp
@@ -35,6 +35,7 @@ kpsr::dds_mdlw::DDSEnv::DDSEnv(const std::string yamlFileName, std::string ddsKe
     , _dataReader(dataReader)
     , _ddsKey(ddsKey)
     , _timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count())
+    , _isEnvLocal(true)
 {
     _listener = new DDSConfigurationListener(ddsKey, this, _timestamp);
     _dataReader->listener(_listener, dds::core::status::StatusMask::data_available());
@@ -47,10 +48,19 @@ kpsr::dds_mdlw::DDSEnv::DDSEnv(YamlEnvironment * yamlEnvironment,
     , _dataWriter(dataWriter)
     , _dataReader(dataReader)
     , _timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count())
+    , _isEnvLocal(false)
 {
     _decorableEnv->getPropertyString("kpsr_dds_env_key", _ddsKey, rootNode);
     _listener = new DDSConfigurationListener(_ddsKey, this, _timestamp);
     _dataReader->listener(_listener, dds::core::status::StatusMask::data_available());
+}
+
+kpsr::dds_mdlw::DDSEnv::~DDSEnv() {
+    _dataReader->listener(nullptr, dds::core::status::StatusMask::data_available());
+    delete _listener;
+    if (_isEnvLocal) {
+        delete _decorableEnv;
+    }
 }
 
 void kpsr::dds_mdlw::DDSEnv::updateConfiguration(const std::string & configurationData) {


### PR DESCRIPTION
Fix potential memory leak in dds environment
Use test fixture to ensure proper shutdown on failure