### PR TITLE
Improve yaml dependency check. Install codegenerator when calling make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,9 @@ ADD_SUBDIRECTORY(thirdparties)
 ADD_SUBDIRECTORY(serialization)
 ADD_SUBDIRECTORY(core)
 ADD_SUBDIRECTORY(high_performance)
-ADD_SUBDIRECTORY(state_machine)
+IF (KPSR_WITH_YAML)
+  ADD_SUBDIRECTORY(state_machine)
+ENDIF()
 if (KPSR_RUNTIME)
 else()
    ADD_SUBDIRECTORY(code_generator)
@@ -245,6 +247,9 @@ export(PACKAGE klepsydra)
 
 # Create the KlepsydraConfig.cmake and KlepsydraConfigVersion files
 include(CMakePackageConfigHelpers)
+IF(KPSR_WITH_YAML)
+  SET(KPSR_YAML_DEP "find_dependency(yaml-cpp 0.5)")
+ENDIF()
 configure_package_config_file(
   "KlepsydraConfig.cmake.in"
   "KlepsydraConfig.cmake"

--- a/KlepsydraConfig.cmake.in
+++ b/KlepsydraConfig.cmake.in
@@ -23,9 +23,6 @@ set(KLEPSYDRA_CODE_GENERATOR "@INSTALL_CMAKE_DIR@/KpsrCodeGen.cmake")
 
 IF (KLEPSYDRA_ZMQ_LIBRARIES)
   find_dependency(cppzmq 4.3 QUIET)
-  find_dependency(yaml-cpp 0.5 QUIET)
 ENDIF()
 
-IF(KLEPSYDRA_DDS_LIBRARIES)
-  find_dependency(yaml-cpp 0.5 QUIET)
-ENDIF()
+@KPSR_YAML_DEP@

--- a/code_generator/kpsr_codegen/CMakeLists.txt
+++ b/code_generator/kpsr_codegen/CMakeLists.txt
@@ -48,10 +48,11 @@ if (Python_FOUND)
     set(INSTALL_PYTHON_BASH_IN "${CMAKE_CURRENT_SOURCE_DIR}/../install_python.sh.in")
     set(INSTALL_PYTHON_BASH    "${CMAKE_CURRENT_BINARY_DIR}/install_python.sh")
     configure_file(${INSTALL_PYTHON_BASH_IN} ${INSTALL_PYTHON_BASH} @ONLY)
-    add_test (NAME kpsr_code_gen_install_python
-        COMMAND ${BASH_PROGRAM} ${INSTALL_PYTHON_BASH}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
-    )
+    add_custom_target (kpsr_code_gen_install_python
+      ALL
+      COMMAND ${BASH_PROGRAM} ${INSTALL_PYTHON_BASH}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+      )
 
     add_nosetests()
 


### PR DESCRIPTION
Currently code generator is installed only when `make test` is invoked. With this fix, code generator is installed when calling `make`.

Also provides better guards for yaml -- when yaml is disabled the `find_dependency` is not invoked and state machine is disabled.