### PR TITLE
Changes needed to embeed kpsr-core as submodule in repo as in kpsr-co…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ ENDIF()
 #Install binaries
 IF(DEFINED THIRDPARTIES_PATH)
 ELSE()
-  SET(THIRDPARTIES_PATH ${CMAKE_SOURCE_DIR}/thirdparties )
+  SET(THIRDPARTIES_PATH ${CMAKE_CURRENT_SOURCE_DIR}/thirdparties )
 ENDIF()
 message(STATUS "Thirdparties install path: " ${THIRDPARTIES_PATH})
 
@@ -50,7 +50,7 @@ ENDIF()
 message(STATUS "Google test path: " ${GTEST_PATH})
 if(DEFINED KPSR_BUILD_PATH)
 else()
-    SET(KPSR_BUILD_PATH ${CMAKE_SOURCE_DIR}/kpsr-build)
+    SET(KPSR_BUILD_PATH ${CMAKE_CURRENT_SOURCE_DIR}/kpsr-build)
 endif()
 message(STATUS "kpsr-build path: " ${KPSR_BUILD_PATH})
 

--- a/core/tests/core_tests/CMakeLists.txt
+++ b/core/tests/core_tests/CMakeLists.txt
@@ -34,8 +34,8 @@ TARGET_LINK_LIBRARIES(${PROJ_NAME} kpsr_core gtest_main)
 
 TARGET_INCLUDE_DIRECTORIES(${PROJ_NAME}
     PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/${PROJ_MAIN_NAME}/tests/common
+    #${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common
     )
 
 add_test(NAME ${PROJ_NAME} COMMAND ${PROJ_NAME} --output-on-failure --gtest_output=xml:gtestresults.xml)

--- a/core/tests/yaml_core_tests/CMakeLists.txt
+++ b/core/tests/yaml_core_tests/CMakeLists.txt
@@ -35,8 +35,8 @@ ADD_EXECUTABLE(${PROJ_NAME} ${${PROJ_NAME}_HEADERS} ${${PROJ_NAME}_SRC} )
 TARGET_LINK_LIBRARIES(${PROJ_NAME} kpsr_core kpsr_core_yaml gtest_main)
 TARGET_INCLUDE_DIRECTORIES(${PROJ_NAME}
   PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_SOURCE_DIR}/${PROJ_MAIN_NAME}/tests/common
+  #${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
   )
 
 add_test(NAME ${PROJ_NAME} COMMAND ${PROJ_NAME} --output-on-failure --gtest_output=xml:gtestresults.xml)


### PR DESCRIPTION
…re-benchmark. As kpsr-core folder is not the CMAKE_SOURCE_DIR in this new structure, some changes are needed to be ablel to compile both alone and as a submodule.